### PR TITLE
fix version number in the html table

### DIFF
--- a/html/download-archive.html
+++ b/html/download-archive.html
@@ -145,7 +145,7 @@ Archive Downloads
 <td><a href="https://github.com/h2database/h2database/releases/download/version-2.0.204/h2-setup-2021-12-21.exe">Windows Installer</a></td>
 <td><a href="https://github.com/h2database/h2database/releases/download/version-2.0.204/h2-2021-12-21.zip">Platform-Independent Zip</a></td>
 </tr>
-<tr><td>1.4.202</td>
+<tr><td>2.0.202</td>
 <td><a href="https://github.com/h2database/h2database/releases/download/version-2.0.202/h2-setup-2021-11-25.exe">Windows Installer</a></td>
 <td><a href="https://github.com/h2database/h2database/releases/download/version-2.0.202/h2-2021-11-25.zip">Platform-Independent Zip</a></td>
 </tr>


### PR DESCRIPTION
From the archive site, I tried to get the latest 1.4 version (which seems to be 1.4.202). But this is 2.0 already.